### PR TITLE
bump stack.yaml to lts-7.19; drop unneeded dependency from cabal file.

### DIFF
--- a/fluxette.cabal
+++ b/fluxette.cabal
@@ -30,7 +30,6 @@ executable fluxette
                      , transformers-compat
                      , react-flux
                      , react-flux-servant
-                     , servant-server
                      , servant-blaze
                      , either
                      , text

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,15 +1,20 @@
 flags: {}
+
 packages:
 - '.'
-- ../react-flux
+
+extra-deps:
+- react-flux-1.2.3
+- react-flux-servant-0.1.1
+
+resolver: lts-7.19
+compiler: ghcjs-0.2.1.9007019_ghc-8.0.1
+compiler-check: match-exact
+
 setup-info:
   ghcjs:
     source:
-      ghcjs-0.2.0.20160414_ghc-7.10.3:
-        url: https://s3.amazonaws.com/ghcjs/ghcjs-0.2.0.20160414_ghc-7.10.3.tar.gz
-        sha1: 6d6f307503be9e94e0c96ef1308c7cf224d06be3
-extra-deps:
-- react-flux-servant-0.1.0
-compiler-check: match-exact
-compiler: ghcjs-0.2.0.20160414_ghc-7.10.3
-resolver: lts-6.1
+      ghcjs-0.2.1.9007019_ghc-8.0.1:
+           url: http://ghcjs.tolysz.org/ghc-8.0-2017-02-05-lts-7.19-9007019.tar.gz
+           sha1: d2cfc25f9cda32a25a87d9af68891b2186ee52f9
+


### PR DESCRIPTION
(servant-server requires network, which currently does not compile on ghcjs.)

(i haven't tried to actually run it, but it compiles!  :-)